### PR TITLE
Update loader to use the new parser interface

### DIFF
--- a/literate/core/loader.py
+++ b/literate/core/loader.py
@@ -4,7 +4,7 @@ import __builtin__
 import os
 from tempfile import NamedTemporaryFile
 import py_compile
-import parser
+from literate.core.parser import untangle
 from contextlib import contextmanager
 
 builtin_import = __builtin__.__import__
@@ -36,7 +36,7 @@ def importer(name, globals=globals(), locals=locals(), fromlist=[], level=-1):
         if location:
             name, path = location
             source = open(path).read()
-            code = parser.python(source)
+            code = untangle(source)['python']
             dest = name + '.py'
             cache_dest = name + '.pyc'
 


### PR DESCRIPTION
Fixes this error:

```
Traceback (most recent call last):
  File "./main.py", line 4, in <module>
    import test1
  File "/Library/Python/2.7/site-packages/literate/core/loader.py", line 39, in importer
    code = parser.python(source)
AttributeError: 'module' object has no attribute 'python'
```
